### PR TITLE
Added Update Custom checkbox

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -280,6 +280,11 @@ function config:Render()
                         settings.save();
                     end
                     imgui.ShowHelp('If enabled, debuffs will include mob index in the target name.  Changes will not apply to existing timers.');
+                    if (imgui.Checkbox('Update Custom##tTimersConfigCustom_UpdateCustom', {gSettings.Custom.UpdateCustom})) then
+                        gSettings.Custom.UpdateCustom = not gSettings.Custom.UpdateCustom;
+                        settings.save();
+                    end
+                    imgui.ShowHelp("When enabled, custom timers will overwrite existing custom timers of the same name, rather than be created again.");
                     imgui.EndTabItem();
                 end
                 imgui.EndTabBar();

--- a/initializer.lua
+++ b/initializer.lua
@@ -124,6 +124,7 @@ gDefaultSettings = T{
         CompletionDuration = 3,
         UseTooltips = true;
         Skin = T{},
+        UpdateCustom = false,
     },
 };
 gSettings = settings.load(gDefaultSettings:copy(true));

--- a/trackers/custom.lua
+++ b/trackers/custom.lua
@@ -27,7 +27,25 @@ tracker.State = {
 };
 
 function tracker:AddTimer(timer)
-    self.State.ActiveTimers:append(timer);
+    if (not gSettings.Custom.UpdateCustom or not tracker:UpdateTimer(timer)) then
+        self.State.ActiveTimers:append(timer);
+    end
+end
+
+function tracker:UpdateTimer(timer)    
+    local found = false
+    for key, existingTimer in ipairs(self.State.ActiveTimers) do
+        if (not found and existingTimer.Label == timer.Label) then
+            existingTimer.Creation = timer.Creation
+            existingTimer.Local = timer.Local
+            existingTimer.Expiration = timer.Expiration
+            existingTimer.TotalDuration = timer.TotalDuration
+            found = true
+        elseif (existingTimer.Label == timer.Label) then
+            existingTimer.Local.Delete = true;
+        end        
+    end
+    return found
 end
 
 function tracker:Tick()

--- a/ttimers.lua
+++ b/ttimers.lua
@@ -22,7 +22,7 @@ SOFTWARE.
 
 addon.name      = 'tTimers';
 addon.author    = 'Thorny';
-addon.version   = '0.10';
+addon.version   = '0.11';
 addon.desc      = 'Displays time remaining on buffs and debuffs you\'ve cast, as well as the recast timers for your spells and abilities.';
 addon.link      = 'https://ashitaxi.com/';
 


### PR DESCRIPTION
Update Custom enables newly created custom times to overwrite previously existing custom timers of the same name, rather than adding to the list.