### PR TITLE
added support to enter a timestamp for custom timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,8 @@ This creates a custom timer with the label and duration specified.  Duration can
 **/tt custom "Reminder" 30s**<br>
 If no suffix is used, the timer will use the number as seconds.
 
+Enter a specific time in the future in this format HH:MM:SS. Example:
+**/tt custom "Timer" 17:13:20**<br>
+
 ## Other
 You can shift-click any timer to make it immediately disappear.  You can ctrl-click any timer to make it immediately disappear and block that ability/buff/debuff from generating new timers in the future.  A future update will allow unblocking through GUI, but currently unblocking must be done by unloading the addon, editing the config file, and reloading the addon.  So, try not to block anything you don't want to keep blocked.

--- a/callbacks.lua
+++ b/callbacks.lua
@@ -117,6 +117,30 @@ ashita.events.register('command', 'command_cb', function (e)
                     if type(time) == 'number' then
                         duration = time * multiplier;
                     end
+                    if (args[4]:len() == 8 or args[4]:len() == 7) and string.find(args[4], ":") then
+                        local datetime = args[4];
+                        local pattern = "(%d+):(%d+):(%d+)";
+                        local hour, min, sec = datetime:match(pattern);
+                        hour = tonumber(hour);
+                        min = tonumber(min);
+                        sec = tonumber(sec);
+
+                        if type(hour) == 'number' and type(min) == 'number' and type(sec) == 'number' then 
+                            local timestamp = os.time({
+                                year = os.date("%Y"),
+                                month = os.date("%m"),
+                                day = os.date("%d"),
+                                hour = hour,
+                                min = min,
+                                sec = sec
+                            });
+                            local now = os.time();
+                            local timeDiff = os.difftime(timestamp, now);
+                            if timeDiff > 0 then
+                                duration = timeDiff;
+                            end
+                        end
+                    end
                 end
                 if (type(duration) == 'number') then
                     local newCustomTimer = {


### PR DESCRIPTION
This PR enhances Custom timer feature to allow users to enter a timestamp such as 20:35:10.