### PR TITLE
Adds the ability to make custom timers repeat

### DIFF
--- a/callbacks.lua
+++ b/callbacks.lua
@@ -151,7 +151,14 @@ ashita.events.register('command', 'command_cb', function (e)
                         TotalDuration = duration;
                     };
                     if (#args > 4) then
-                        newCustomTimer.Tooltip = args[5];
+                        if (args[5] == 'repeat') then
+                            newCustomTimer.Repeating = true;
+                            if (#args > 5) then
+                                newCustomTimer.Tooltip = args[6];
+                            end
+                        else
+                            newCustomTimer.Tooltip = args[5];
+                        end
                     end
                     customTracker:AddTimer(newCustomTimer);
                 end

--- a/callbacks.lua
+++ b/callbacks.lua
@@ -167,10 +167,19 @@ ashita.events.register('command', 'command_cb', function (e)
             return;
         end
 
+        if (args[2] == 'stop') then
+            if (#args > 2) then
+                customTracker:DeleteTimer(args[3]);
+            end
+            e.blocked = true;
+            return;
+        end
+
         print(chat.header('tTimers') .. chat.message('Command Descriptions:'));
         print(chat.header('tTimers') .. chat.color1(2, '/tt') .. chat.message(' - Opens configuration menu.'));
         print(chat.header('tTimers') .. chat.color1(2, '/tt reposition') .. chat.message(' - Starts reposition mode, which shows debug timers to fill all panels and provides draggable handles to move them.'));
         print(chat.header('tTimers') .. chat.color1(2, '/tt lock') .. chat.message(' - Ends repositioning mode and saves positions for the current character.'));
         print(chat.header('tTimers') .. chat.color1(2, '/tt custom [label] [duration]') .. chat.message(' - Adds a custom timer.  Duration can be specified in number of seconds or using s,m, or h suffixes with or without decimal places(30m, 1h, 10.5m, etc).'));
+        print(chat.header('tTimers') .. chat.color1(2, '/tt stop [label]') .. chat.message(' - Deletes a custom timer.'));
     end
 end);

--- a/trackers/custom.lua
+++ b/trackers/custom.lua
@@ -48,10 +48,29 @@ function tracker:UpdateTimer(timer)
     return found
 end
 
+function tracker:DeleteTimer(label)
+    for key, existingTimer in ipairs(self.State.ActiveTimers) do
+        if (existingTimer.Label == label) then
+            existingTimer.Local.Delete = true;
+        end        
+    end
+end
+
 function tracker:Tick()
     local time = os.clock();
     self.State.ActiveTimers = self.State.ActiveTimers:filteri(function(a) return (a.Local.Delete ~= true) end);
-    self.State.ActiveTimers:each(function(a) a.Duration = a.Expiration - time; end);
+    for key, existingTimer in ipairs(self.State.ActiveTimers) do
+        existingTimer.Duration = existingTimer.Expiration - time
+        if (existingTimer.Repeating == true and existingTimer.Duration <= 0) then
+            local newTimer = table.clone(existingTimer)
+            newTimer.Creation = time
+            newTimer.Local = T{}
+            newTimer.Expiration = time + existingTimer.TotalDuration
+            newTimer.Duration = existingTimer.TotalDuration
+            tracker:AddTimer(newTimer)
+            existingTimer.Repeating = false
+        end
+    end
     return self.State.ActiveTimers;
 end
 

--- a/ttimers.lua
+++ b/ttimers.lua
@@ -22,7 +22,7 @@ SOFTWARE.
 
 addon.name      = 'tTimers';
 addon.author    = 'Thorny';
-addon.version   = '0.15';
+addon.version   = '0.16';
 addon.desc      = 'Displays time remaining on buffs and debuffs you\'ve cast, as well as the recast timers for your spells and abilities.';
 addon.link      = 'https://ashitaxi.com/';
 


### PR DESCRIPTION
I'd like the ability to have custom timers loop themselves over and over again automatically so this PR provides one way to accomplish that.

It checks for the repeat keyword when creating a custom timer.

i.e. 
```
/tt custom [label] [duration] repeat [tooltip]
```

Alternatively, this could be added to a new command. e.g. /tt repeating?

This also adds the /tt stop [label] command to delete custom timers.