### PR TITLE
Add Foe Requiem duration support

### DIFF
--- a/durations/songs.lua
+++ b/durations/songs.lua
@@ -432,60 +432,55 @@ local function CalculateLullabyDuration(base)
     return CalculateDebuffSongDuration(base, SongSum() + dataTracker:EquipSum(lullabyEquipment), true);
 end
 
+local function CalculateRequiemDuration(base)
+    return CalculateDebuffSongDuration(base, SongSum() + dataTracker:EquipSum(requiemEquipment), false);
+end
+
 local function CalculateThrenodyDuration(base)
     return CalculateDebuffSongDuration(base, SongSum() + dataTracker:EquipSum(threnodyEquipment), false);
 end
 
 local function Initialize(tracker, buffer)
     dataTracker = tracker;
-    --[[UNKNOWN
+
+
+    --Requiem base duration is 48 + 16 * tier
+    --https://wiki.ffo.jp/html/4264.html
+
     --Foe Requiem
 	buffer[368] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16), 192;
 	end
-    ]]--
     
-    --[[UNKNOWN
 	--Foe Requiem II
 	buffer[369] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16 * 2), 192;
 	end
-    ]]--
     
-    --[[UNKNOWN
 	--Foe Requiem III
 	buffer[370] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16 * 3), 192;
 	end
-    ]]--
 
-    --[[UNKNOWN
 	--Foe Requiem IV
 	buffer[371] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16 * 4), 192;
 	end
-    ]]--
 
-    --[[UNKNOWN
 	--Foe Requiem V
 	buffer[372] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16 * 5), 192;
 	end
-    ]]--
 
-    --[[UNKNOWN
 	--Foe Requiem VI
 	buffer[373] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16 * 6), 192;
 	end
-    ]]--
 
-    --[[UNKNOWN
 	--Foe Requiem VII
 	buffer[374] = function(targetId)
-		return 0;
+        return CalculateRequiemDuration(48 + 16 * 7), 192;
 	end
-    ]]--
 
 	--Horde Lullaby
 	buffer[376] = function(targetId)


### PR DESCRIPTION
JP wiki states base duration = 48 + 16 * tier, see https://wiki.ffo.jp/html/4264.html

And here's some data of testing I did on retail. It looks like duration bonuses are actually x/256 based on my data (though packet jitter could come into play. being off by 1 second isn't huge though.)

```
timestamp samples

foe requiem 1:
17:19
18:59

60+40 = 100s

foe requiem 2:
31:45
33:50

60+60+5 = 125

foe requiem 3:
36:41
39:11

60+60+30 = 150


foe requiem 4:
42:46
45:41
60+60+55 = 175

foe requiem 5:
50:02
51:42

60+40 = 100 (expected 200, half resist?)

58:13
01:33
60+60+60+20 = 200

foe requiem 6:

04:27
08:12
60+60+60+45 = 225

foe requiem 7:
13:51
18:01
60+60+60+60+10 = 250


all songs +2+2 + 10% duration bonus each (no x/256 nonsense)

duration bonuses in x/256

gear: song duration +12% (0.1171875)
JP gift +5% (0.046875)
Foe Requiem 6/7 data is off by 1 second unless x/256 is accounted for

Foe Requiem 1:
(48+(16*1)) * (1.1640625+.10*4))= 100.1: match

Foe Requiem 2:
(48+(16*2)) * (1.1640625+.10*4)) = 125.125: match

Foe Requiem 3:
(48+(16*3)) * (1.1640625+.10*4)) = 150.15: match

Foe Requiem 4:
(48+(16*4)) * (1.1640625+.10*4)) = 175.175: match

Foe Requiem 5:
(48+(16*5)) * (1.1640625+.10*4)) = 200.2: matches half resist data and full duration data

Foe Requiem 6:
(48+(16*6)) * (1.1640625+.10*4)) = 225.225: match

Foe Requiem 7:
(48+(16*7)) * (1.1640625+.10*4)) = 250.25: match
```