### PR TITLE
Add command to callbacks

### DIFF
--- a/callbacks.lua
+++ b/callbacks.lua
@@ -98,6 +98,52 @@ ashita.events.register('command', 'command_cb', function (e)
             return;
         end
 
+        if (args[2] == 'nm') then
+            local countdown;
+            if (#args >= 4) then
+                if type(args[4]) == 'string' then
+                    local hour, min, sec = args[4]:match("(%d+):(%d+):(%d+)")
+                    local targetSeconds = tonumber(hour) * 3600 + tonumber(min) * 60 + tonumber(sec)
+        
+                    local now = os.date("*t")
+                    local currentSeconds = now.hour * 3600 + now.min * 60 + now.sec
+        
+                    countdown = targetSeconds - currentSeconds
+                end
+
+                if (type(countdown) == 'number' and type(args[5]) == 'string') then
+                    local multiplier = 1;
+                    local trail = string.lower(string.sub(args[5], -1, -1));
+                    if trail == 's' then
+                        args[5] = args[5]:sub(1, -2);
+                    elseif (trail == 'm') then
+                        multiplier = 60;
+                        args[5] = args[5]:sub(1, -2);
+                    elseif (trail == 'h') then
+                        multiplier = 3600;
+                        args[5] = args[5]:sub(1, -2);
+                    end
+                    local time = tonumber(args[5]);
+                    if type(time) == 'number' then
+                        countdown = (time * multiplier) + countdown;
+                    end
+                end
+
+                if(type(countdown) == 'number') then
+                    local newCustomTimer = {
+                        Creation = os.clock(),
+                        Label = args[3],
+                        Local = T{},
+                        Expiration = os.clock() + countdown,
+                        TotalDuration = countdown;
+                    };
+                    customTracker:AddTimer(newCustomTimer);
+                end
+            end
+            e.blocked = true;
+            return;
+        end
+
         if (args[2] == 'custom') then
             if (#args >= 4) then
                 local duration;
@@ -151,25 +197,10 @@ ashita.events.register('command', 'command_cb', function (e)
                         TotalDuration = duration;
                     };
                     if (#args > 4) then
-                        if (args[5] == 'repeat') then
-                            newCustomTimer.Repeating = true;
-                            if (#args > 5) then
-                                newCustomTimer.Tooltip = args[6];
-                            end
-                        else
-                            newCustomTimer.Tooltip = args[5];
-                        end
+                        newCustomTimer.Tooltip = args[5];
                     end
                     customTracker:AddTimer(newCustomTimer);
                 end
-            end
-            e.blocked = true;
-            return;
-        end
-
-        if (args[2] == 'stop') then
-            if (#args > 2) then
-                customTracker:DeleteTimer(args[3]);
             end
             e.blocked = true;
             return;
@@ -180,6 +211,6 @@ ashita.events.register('command', 'command_cb', function (e)
         print(chat.header('tTimers') .. chat.color1(2, '/tt reposition') .. chat.message(' - Starts reposition mode, which shows debug timers to fill all panels and provides draggable handles to move them.'));
         print(chat.header('tTimers') .. chat.color1(2, '/tt lock') .. chat.message(' - Ends repositioning mode and saves positions for the current character.'));
         print(chat.header('tTimers') .. chat.color1(2, '/tt custom [label] [duration]') .. chat.message(' - Adds a custom timer.  Duration can be specified in number of seconds or using s,m, or h suffixes with or without decimal places(30m, 1h, 10.5m, etc).'));
-        print(chat.header('tTimers') .. chat.color1(2, '/tt stop [label]') .. chat.message(' - Deletes a custom timer.'));
+        print(chat.header('tTimers') .. chat.color1(2, '/tt nm [label] [start] [elapsed]') .. chat.message(' - Adds an nm timer. Start can be specified in HH:MM:SS format in local time. Elapsed is time since window to next pop, specified the same way as duration.'));
     end
 end);


### PR DESCRIPTION
Closes #30 

It adds a new command, /tt nm [label] [window] [optional: elapsed] which can be used as follows:

/tt nm "Jaggedy-Eared Jack" 10:44:32 2h
10:44:32 is your local timestamp of when the window opens or when JEJ died, for example; the elapsed is how long after that timestamp you want your timer to count down to. This is useful both for on kill, and for upcoming windows in my experience.