### PR TITLE
Merge same buffs together into 1 timer

### DIFF
--- a/callbacks.lua
+++ b/callbacks.lua
@@ -25,7 +25,7 @@ local ffi = require('ffi');
 local config        = require('config');
 local customTracker = require('trackers.custom');
 local dummyTracker  = require('trackers.dummy');
-local trackers      = T{
+gTrackers      = T{
     { Name='Buff',   Tracker=require('trackers.buff') },
     { Name='Debuff', Tracker=require('trackers.debuff') },
     { Name='Recast', Tracker=require('trackers.recast') },
@@ -47,7 +47,7 @@ ashita.events.register('d3d_present', 'd3d_present_cb', function ()
     end
 
     sprite:Begin();
-    for _,entry in ipairs(trackers) do
+    for _,entry in ipairs(gTrackers) do
         local panel = gPanels[entry.Name];
         if (panel.ShowDebugTimers) then
             entry.Tracker:Tick();
@@ -56,8 +56,8 @@ ashita.events.register('d3d_present', 'd3d_present_cb', function ()
             panel:Render(sprite, entry.Tracker:Tick());
         end
     end
-    for i = #trackers,1,-1 do
-        local panel = gPanels[trackers[i].Name];
+    for i = #gTrackers,1,-1 do
+        local panel = gPanels[gTrackers[i].Name];
         panel:RenderTooltip(sprite);
     end
     sprite:End();

--- a/config.lua
+++ b/config.lua
@@ -25,7 +25,7 @@ local imgui = require('imgui');
 local panels = T { 'Buff', 'Debuff', 'Recast', 'Custom' };
 local sortTypes = T { 'Nominal', 'Percentage', 'Alphabetical', 'Creation' };
 local trackModes = T { 'Self Cast Only', 'Party Only', 'Alliance Only', 'All Players' };
-local splitModes = T { "Combine Timers (Duration %)", "Combine Timers (Seconds)", "Don't Combine Timers" };
+local splitModes = T { "Combine All Timers", "Combine Timers (Duration %)", "Combine Timers (Seconds)", "Don't Combine Timers" };
 
 local blockeditor = require('blockeditor');
 local config = {
@@ -33,6 +33,14 @@ local config = {
         IsOpen = { false },
     },
 };
+
+local function RebuildBuffs()
+    for _,tracker in ipairs(gTrackers) do
+        if tracker.Name == "Buff" then
+            tracker.Tracker:ForceRebuild();
+        end
+    end
+end
 
 function config:LoadRenderers()
     local renderers = T{};
@@ -249,6 +257,7 @@ function config:Render()
                                     else
                                         gSettings.Buff.SplitValue = nil;
                                     end
+                                    RebuildBuffs();
                                     settings.save();
                                 end
                             end
@@ -260,12 +269,14 @@ function config:Render()
                         local buffer = { gSettings.Buff.SplitValue };                        
                         if (imgui.SliderFloat(string.format('##tTimersBuffSplitPercent'), buffer, 0.1, 1.0, '%.2f', ImGuiSliderFlags_AlwaysClamp)) then
                             gSettings.Buff.SplitValue = buffer[1];
+                            RebuildBuffs();
                             settings.save();
                         end
                     elseif gSettings.Buff.SplitMode == "Combine Timers (Seconds)" then
                         local buffer = { gSettings.Buff.SplitValue };                        
                         if (imgui.SliderInt(string.format('##tTimersBuffSplitSeconds'), buffer, 1, 90, '%u', ImGuiSliderFlags_AlwaysClamp)) then
                             gSettings.Buff.SplitValue = buffer[1];
+                            RebuildBuffs();
                             settings.save();
                         end
                     end

--- a/config.lua
+++ b/config.lua
@@ -25,6 +25,7 @@ local imgui = require('imgui');
 local panels = T { 'Buff', 'Debuff', 'Recast', 'Custom' };
 local sortTypes = T { 'Nominal', 'Percentage', 'Alphabetical', 'Creation' };
 local trackModes = T { 'Self Cast Only', 'Party Only', 'Alliance Only', 'All Players' };
+local splitModes = T { "Combine Timers (Duration %)", "Combine Timers (Seconds)", "Don't Combine Timers" };
 
 local blockeditor = require('blockeditor');
 local config = {
@@ -58,7 +59,6 @@ end
 
 function config:LoadSkins()
     local skins = T{};
-    local panels = T{ 'Buff', 'Debuff', 'Recast', 'Custom' };
     for _,panelName in ipairs(panels) do
         local renderer = gSettings[panelName].Renderer;
         if (skins[renderer] == nil) then
@@ -235,12 +235,42 @@ function config:Render()
                 self:DrawPanelTab('Recast');
                 self:DrawPanelTab('Custom');
                 if imgui.BeginTabItem(string.format('Behavior##tTimersConfigBehaviorTab')) then
-                    imgui.TextColored(header, 'Buffs');
-                    if (imgui.Checkbox('Split By Duration##tTimersConfigBuffs_SplitByDuration', { gSettings.Buff.SplitByDuration })) then
-                        gSettings.Buff.SplitByDuration = not gSettings.Buff.SplitByDuration;
-                        settings.save();
+                    imgui.TextColored(header, 'Buff Splitting');
+                    local buffSplitMode = gSettings.Buff.SplitMode;
+                    if (imgui.BeginCombo(string.format('##tTimersBuffSplitMode'), buffSplitMode, ImGuiComboFlags_None)) then
+                        for _,splitMode in ipairs(splitModes) do
+                            if (imgui.Selectable(splitMode, splitMode == buffSplitMode)) then
+                                if (splitMode ~= buffSplitMode) then
+                                    gSettings.Buff.SplitMode = splitMode;
+                                    if splitMode == "Combine Timers (Duration %)" then
+                                        gSettings.Buff.SplitValue = 0.9;
+                                    elseif splitMode == "Combine Timers (Seconds)" then
+                                        gSettings.Buff.SplitValue = 2;
+                                    else
+                                        gSettings.Buff.SplitValue = nil;
+                                    end
+                                    settings.save();
+                                end
+                            end
+                        end
+                        imgui.EndCombo();
                     end
-                    imgui.ShowHelp('If enabled, the same buff will show up multiple times for each different duration.');
+                    imgui.ShowHelp('Determines when buffs with similar durations will be combined.');
+                    if gSettings.Buff.SplitMode == "Combine Timers (Duration %)" then
+                        local buffer = { gSettings.Buff.SplitValue };                        
+                        if (imgui.SliderFloat(string.format('##tTimersBuffSplitPercent'), buffer, 0.1, 1.0, '%.2f', ImGuiSliderFlags_AlwaysClamp)) then
+                            gSettings.Buff.SplitValue = buffer[1];
+                            settings.save();
+                        end
+                    elseif gSettings.Buff.SplitMode == "Combine Timers (Seconds)" then
+                        local buffer = { gSettings.Buff.SplitValue };                        
+                        if (imgui.SliderInt(string.format('##tTimersBuffSplitSeconds'), buffer, 1, 90, '%u', ImGuiSliderFlags_AlwaysClamp)) then
+                            gSettings.Buff.SplitValue = buffer[1];
+                            settings.save();
+                        end
+                    end
+
+                    imgui.TextColored(header, 'Buff Tracking');
                     local buffTrackMode = gSettings.Buff.TrackMode;
                     if (imgui.BeginCombo(string.format('##tTimersBuffTrackMode'), buffTrackMode, ImGuiComboFlags_None)) then
                         for _,trackMode in ipairs(trackModes) do

--- a/initializer.lua
+++ b/initializer.lua
@@ -48,7 +48,8 @@ gDefaultSettings = T{
         SpellIconList = T{},
         AbilityIconList = T{},
         WeaponSkillIconList = T{},
-        SplitByDuration = true,
+        SplitMode = "Combine Timers (Seconds)";
+        SplitValue = 2;
         TrackMode = 'Self Cast Only',
         Blocked = T{
             --Add reasonable defaults..
@@ -126,6 +127,22 @@ gDefaultSettings = T{
     HideWithPrimitives = true,
 };
 gSettings = settings.load(gDefaultSettings:copy(true));
+
+-- Update settings to match current version..
+do
+    -- Convert Split By Duration from boolean to state + value
+    if gSettings.SplitByDuration ~= nil then
+        if gSettings.SplitByDuration then
+            gSettings.SplitMode = "Combine Timers (Seconds)"
+            gSettings.SplitValue = 2;
+        else
+            gSettings.SplitMode = "Don't Combine Timers";
+            gSettings.SplitValue = 2;
+        end
+        gSettings.SplitByDuration = nil;
+    end
+    
+end
 
 --Initialize panels..
 local group          = require('timergroup');

--- a/trackers/buff.lua
+++ b/trackers/buff.lua
@@ -694,16 +694,39 @@ local function CreateTimer(buffData)
     activeTimers:append(timerData);
 end
 
+local function GetSplitTolerance(targetExpiration)
+    local remaining = targetExpiration - os.clock()
+
+    -- 90% of duration
+    local tolerance = remaining * 0.90
+    tolerance = math.max(60, math.min(180, tolerance))
+
+    return tolerance
+end
+
 local function CreateSplitTimers(buffData)
     local timers = T{};
     for id,target in pairs(buffData.Targets) do
         local targetTimer;
+        local mergeSetting = true -- TODO: Real Setting
+
         for _,timer in ipairs(timers) do
-            if (math.abs(timer.Expiration - target.Expiration) < 2) then
-                targetTimer = timer;
-                break;
+            if mergeSetting then
+                local tolerance = GetSplitTolerance(target.Expiration)
+                
+                if (math.abs(timer.Expiration - target.Expiration) < tolerance) then
+                    for _,timer in ipairs(timers) do
+                        targetTimer = timer;
+                    end
+                end
+            else
+                if (math.abs(timer.Expiration - target.Expiration) < 2) then
+                    targetTimer = timer;
+                    break;
+                end
             end
         end
+
         if not targetTimer then
             targetTimer = {
                 BuffId = buffData.BuffId,

--- a/trackers/buff.lua
+++ b/trackers/buff.lua
@@ -694,39 +694,32 @@ local function CreateTimer(buffData)
     activeTimers:append(timerData);
 end
 
-local function GetSplitTolerance(targetExpiration)
-    local remaining = targetExpiration - os.clock()
-
-    -- 90% of duration
-    local tolerance = remaining * 0.90
-    tolerance = math.max(60, math.min(180, tolerance))
-
-    return tolerance
+local function ShouldMerge(timer1, timer2)
+    if gSettings.Buff.SplitMode == "Don't Combine Timers" then
+        return false;
+    elseif gSettings.Buff.SplitMode == "Combine Timers (Seconds)" then
+        return (math.abs(timer2 - timer1) < gSettings.Buff.SplitValue);
+    elseif timer1 < timer2 then
+        return ((timer1 / timer2) > gSettings.Buff.SplitValue);
+    else
+        return ((timer2 / timer1) > gSettings.Buff.SplitValue);
+    end
 end
 
 local function CreateSplitTimers(buffData)
     local timers = T{};
     for id,target in pairs(buffData.Targets) do
         local targetTimer;
-        local mergeSetting = true -- TODO: Real Setting
 
+        -- Look for a mergable timer..
         for _,timer in ipairs(timers) do
-            if mergeSetting then
-                local tolerance = GetSplitTolerance(target.Expiration)
-                
-                if (math.abs(timer.Expiration - target.Expiration) < tolerance) then
-                    for _,timer in ipairs(timers) do
-                        targetTimer = timer;
-                    end
-                end
-            else
-                if (math.abs(timer.Expiration - target.Expiration) < 2) then
-                    targetTimer = timer;
-                    break;
-                end
+            if (ShouldMerge(timer.Expiration, target.Expiration)) then
+                targetTimer = timer;
+                break;
             end
         end
 
+        -- Or create a new timer..
         if not targetTimer then
             targetTimer = {
                 BuffId = buffData.BuffId,
@@ -738,6 +731,7 @@ local function CreateSplitTimers(buffData)
             };
             timers:append(targetTimer);
         end
+
         targetTimer.Targets[id] = target;
     end
     for _,timer in ipairs(timers) do
@@ -746,15 +740,15 @@ local function CreateSplitTimers(buffData)
 end
 
 --Split out all buff timers by resource key, then sort them out into new timers.
-local function RebuildTimers(splitByDuration)
+local function RebuildTimers()
     activeTimers = T{};
 
     for key,buffData in pairs(buffsByAction) do
         if (gSettings.Buff.Blocked[key] == nil) then
-            if splitByDuration then
-                CreateSplitTimers(buffData);
-            else
+            if gSettings.Buff.SplitMode == "Combine All Timers" then
                 CreateTimer(buffData);
+            else
+                CreateSplitTimers(buffData);
             end
         end
     end
@@ -777,13 +771,15 @@ end
 
 local exports = {};
 
-local lastSetting;
+function exports:ForceRebuild()
+    rebuildTimers = true;
+end
+
 function exports:Tick()
     ClearDeletedTimers();
 
-    if (rebuildTimers) or (gSettings.Buff.SplitByDuration ~= lastSetting) then
-        lastSetting = gSettings.Buff.SplitByDuration;
-        RebuildTimers(lastSetting);
+    if rebuildTimers then
+        RebuildTimers();
         rebuildTimers = false;
     else
         for _,timerData in ipairs(activeTimers) do


### PR DESCRIPTION
This will merge together buffs into a single timer if they're within 90% of the total duration

Current:
I haste 6 people 1 at a time
I have 6 different buff bars drawn for haste because they're a few seconds apart due to it having a recast

This PR:
I haste 6 people 1 at a time
There's 1 buff bar, and it  shows +5 or w/e to indicate 5 more people
Persons name shown on it is first person buffed